### PR TITLE
docs: Add sentinel(1) manpage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,10 +175,30 @@ clean:
 	rm -rf $(BUILD_DIR) $(BIN_DIR)
 	@echo "Cleaned build artifacts"
 
+<<<<<<< HEAD
 # ============================================================
 # Test
 # ============================================================
 
+=======
+# Install
+PREFIX ?= /usr/local
+install: all
+	install -d $(PREFIX)/bin
+	install -m 755 $(SENTINEL) $(PREFIX)/bin/
+	install -m 755 $(SENTINEL_DIFF) $(PREFIX)/bin/
+	install -d $(PREFIX)/share/man/man1
+	install -m 644 man/sentinel.1 $(PREFIX)/share/man/man1/
+	@echo "Installed to $(PREFIX)/bin/"
+
+# Uninstall
+uninstall:
+	rm -f $(PREFIX)/bin/sentinel
+	rm -f $(PREFIX)/bin/sentinel-diff
+	rm -f $(PREFIX)/share/man/man1/sentinel.1
+
+# Test suite
+>>>>>>> 2e740dc (docs: Add sentinel(1) manpage)
 test: all
 	@echo "=== C-Sentinel Test Suite ==="
 	@echo ""

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,12 @@ echo -e "${YELLOW}Installing binary...${NC}"
 cp bin/sentinel /usr/local/bin/sentinel
 chmod 755 /usr/local/bin/sentinel
 
+# Install manpage
+echo -e "${YELLOW}Installing manpage...${NC}"
+install -d /usr/local/share/man/man1
+install -m 644 man/sentinel.1 /usr/local/share/man/man1/
+mandb 2>/dev/null || true  # Update man database (optional, may fail)
+
 # Install config file template
 if [ ! -f /etc/sentinel/config ]; then
     echo -e "${YELLOW}Installing default config...${NC}"

--- a/man/sentinel.1
+++ b/man/sentinel.1
@@ -1,0 +1,147 @@
+.TH SENTINEL 1 "2025-01-09" "C-Sentinel 0.6.0" "User Commands"
+.SH NAME
+sentinel \- semantic observability for UNIX systems
+.SH SYNOPSIS
+.B sentinel
+.RB [ \-hqvjwnab ]
+.RB [ \-i
+.IR seconds ]
+.RI [ config_files... ]
+.SH DESCRIPTION
+.B sentinel
+probes system state and configuration, identifying anomalies such as
+zombie processes, unusual network listeners, permission issues, and
+configuration drift.
+Output may be human-readable or JSON.
+.PP
+If no
+.I config_files
+are specified, sentinel probes common system configuration files.
+.SH OPTIONS
+.TP
+.BR \-h ", " \-\-help
+Print usage summary and exit.
+.TP
+.BR \-q ", " \-\-quick
+Show quick analysis summary only.
+.TP
+.BR \-v ", " \-\-verbose
+Include all processes, not just notable ones.
+.TP
+.BR \-j ", " \-\-json
+Output JSON to stdout.
+.TP
+.BR \-w ", " \-\-watch
+Continuous monitoring mode.
+.TP
+.BR \-i ", " \-\-interval " " \fIseconds\fR
+Probe interval in watch mode.
+Default: 60.
+.TP
+.BR \-n ", " \-\-network
+Include network probe (listeners, connections).
+.TP
+.BR \-a ", " \-\-audit
+Include auditd security events.
+.TP
+.BR \-b ", " \-\-baseline
+Compare against learned baseline.
+.TP
+.BR \-l ", " \-\-learn
+Learn current state as baseline.
+.TP
+.BR \-c ", " \-\-config
+Show current configuration.
+.TP
+.B \-\-init\-config
+Create default configuration file.
+.TP
+.B \-\-audit\-learn
+Learn audit baseline.
+.TP
+.B \-\-color
+Force coloured output.
+.TP
+.B \-\-no\-color
+Disable coloured output.
+.SH EXIT STATUS
+.TP
+.B 0
+No issues detected.
+.TP
+.B 1
+Warnings (minor issues).
+.TP
+.B 2
+Critical (zombies, permission issues, unusual ports, security events).
+.TP
+.B 3
+Error (probe failed).
+.SH ENVIRONMENT
+.TP
+.B NO_COLOR
+Disable coloured output (standard).
+.SH FILES
+.TP
+.I ~/.sentinel/config
+User configuration file.
+.TP
+.I ~/.sentinel/baseline.json
+Learned baseline state.
+.SH EXAMPLES
+Quick analysis:
+.PP
+.RS
+.nf
+sentinel \-\-quick
+.fi
+.RE
+.PP
+Include network and audit probes:
+.PP
+.RS
+.nf
+sentinel \-\-quick \-\-network \-\-audit
+.fi
+.RE
+.PP
+Learn baseline:
+.PP
+.RS
+.nf
+sentinel \-\-learn \-\-network
+.fi
+.RE
+.PP
+Compare against baseline:
+.PP
+.RS
+.nf
+sentinel \-\-baseline \-\-network
+.fi
+.RE
+.PP
+Save JSON fingerprint:
+.PP
+.RS
+.nf
+sentinel \-\-json > fingerprint.json
+.fi
+.RE
+.PP
+Continuous monitoring:
+.PP
+.RS
+.nf
+sentinel \-\-watch \-\-interval 300
+.fi
+.RE
+.SH SEE ALSO
+.BR auditd (8),
+.BR auditctl (8),
+.BR netstat (8),
+.BR ss (8)
+.SH AUTHORS
+William Murray
+.UR https://github.com/williamofai/c\-sentinel
+.UE


### PR DESCRIPTION
## docs: Add sentinel(1) manpage

Adds a traditional UNIX manpage for sentinel.

### Changes
- `man/sentinel.1` - troff manpage covering options, exit codes, environment, examples
- `install.sh` - installs manpage to `/usr/local/share/man/man1/` when present

### Notes
- Follows conventions (terse, no fluff)
- Install is guarded; won't break if `man/` directory missing
- Closes the "Man page" item

### Testing
```bash
man ./man/sentinel.1
# or
groff -man -Tutf8 man/sentinel.1 | less
```